### PR TITLE
Eliminates "//" for href="/..." case; avoids rewriting when no rules match

### DIFF
--- a/class-wpcdnrewrite.php
+++ b/class-wpcdnrewrite.php
@@ -324,9 +324,6 @@ class WP_CDN_Rewrite {
 					
 					if ( $this->starts_with( $url, '/' ) ) {
 						$base = network_site_url();
-						if ( ! $this->starts_with( $base, '/' ) ) {
-							$base = $base . '/';
-						}
 						$url = $base . $url;
 					}
 					$parsed = parse_url( $url );
@@ -348,7 +345,8 @@ class WP_CDN_Rewrite {
 								}
 							}
 							
-							$tag->setAttribute( $attribute, $this->rewrite_url( $url, $matchedRule ) );
+							if ( NULL != $matchedRule )
+								$tag->setAttribute( $attribute, $this->rewrite_url( $url, $matchedRule ) );
 						}
 					}
 				}
@@ -367,10 +365,6 @@ class WP_CDN_Rewrite {
 	 * @return    string  The rewritten URL
      */
     protected function rewrite_url( $url, $rule ) {
-    	if ( NULL == $rule ) {
-    		return $url;
-    	}
-    	
     	$ret = $url;
     	
 		if ( self::REWRITE_TYPE_HOST_ONLY == $rule['type'] ) {


### PR DESCRIPTION
The deletions at lines 327-329 handle an issue I was having where the plugin was producing double-slashed URLs. For instance, "/cvx/cvx-w32.zip" was replaced with "http://cvxr.com//cvx/cvx-w32.zip" instead of "http://cvxr.com/cvx/cvx-w32.zip" 

I'm not sure why these lines were necessary: the surrounding 'if' statement establishes that `$url` has an opening slash, so `network_site_url() . $url` should do just fine. But even so, `starts_with( $base, '/' )` doesn't seem to make sense; that should _never_ evaluate to true for any well-formed URL. Perhaps you meant to use `ends_with`? But again, I see no reason for it anyway, though I may be missing something.

A few lines later, I modified the code so that if no matching rule is found, the URL is left unchanged. In other words, "/cvx/cvx-w32.zip" should be _left as-is_ (if the file type doesn't match, of course), instead of being replaced with "http://cvxr.com/cvx/cvx-w32.zip".
